### PR TITLE
Fix typo in "daemon" thread mode enable.

### DIFF
--- a/spalloc/job.py
+++ b/spalloc/job.py
@@ -240,7 +240,7 @@ class Job(object):
         self._keepalive_thread = threading.Thread(
             target=self._keepalive_thread,
             name="job-keepalive-thread")
-        self._keepalive_thread.deamon = True
+        self._keepalive_thread.daemon = True
 
         # Event fired when the background thread should shut-down
         self._stop = threading.Event()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -159,9 +159,9 @@ class TestKeepalive(object):
 
     def test_normal_operation(self, client, no_config_files):
         # Make sure that the keepalive is sent out at the correct interval by
-        # the background thread.
-        client.job_keepalive
+        # the background thread (and make sure this thread is daemonic
         j = Job(hostname="localhost", owner="me", keepalive=0.2)
+        assert j._keepalive_thread.daemon is True
         time.sleep(0.5)
         j.close()
 


### PR DESCRIPTION
The 'Job' object previously had a typo in the line making the keepalive thread
a daemon... A test has now been added to check this flag too... Whoops.