### PR TITLE
Interpret incoming timestamps as UTC.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     keywords="spinnaker allocation packing management supercomputer",
 
     # Requirements
-    install_requires=["six>=1.8.0", "appdirs", "enum-compat"],
+    install_requires=["six>=1.8.0", "appdirs", "enum-compat", "pytz", "tzlocal"],
 
     # Scripts
     entry_points={

--- a/spalloc/scripts/job.py
+++ b/spalloc/scripts/job.py
@@ -63,6 +63,9 @@ import sys
 import argparse
 import datetime
 
+from pytz import utc
+from tzlocal import get_localzone
+
 from collections import OrderedDict
 
 from six import iteritems
@@ -122,8 +125,10 @@ def show_job_info(t, client, timeout, job_id):
         info["Owner"] = job["owner"]
         info["State"] = JobState(job["state"]).name
         if job["start_time"] is not None:
-            info["Start time"] = datetime.datetime.fromtimestamp(
-                job["start_time"]).strftime('%d/%m/%Y %H:%M:%S')
+            utc_timestamp = datetime.datetime.fromtimestamp(
+                job["start_time"], utc)
+            local_timestamp = utc_timestamp.astimezone(get_localzone())
+            info["Start time"] = local_timestamp.strftime('%d/%m/%Y %H:%M:%S')
         info["Keepalive"] = job["keepalive"]
 
         args = job["args"]

--- a/spalloc/scripts/ps.py
+++ b/spalloc/scripts/ps.py
@@ -15,6 +15,9 @@ import sys
 import argparse
 import datetime
 
+from pytz import utc
+from tzlocal import get_localzone
+
 from spalloc import config
 from spalloc import \
     __version__, ProtocolClient, ProtocolTimeoutError, JobState
@@ -87,8 +90,10 @@ def render_job_list(t, jobs, machine=None, owner=None):
             num_boards = ""
 
         # Format start time
-        timestamp = datetime.datetime.fromtimestamp(
-            job["start_time"]).strftime('%d/%m/%Y %H:%M:%S')
+        utc_timestamp = datetime.datetime.fromtimestamp(
+            job["start_time"], utc)
+        local_timestamp = utc_timestamp.astimezone(get_localzone())
+        timestamp = local_timestamp.strftime('%d/%m/%Y %H:%M:%S')
 
         if job["allocated_machine_name"] is not None:
             machine_name = job["allocated_machine_name"]


### PR DESCRIPTION
Once project-rig/spalloc_server#4 is merged, this will ensure that the spalloc client utilities report times correctly for the local timezone.